### PR TITLE
[BUG-66509] Return `null` when the `<a:off>` tag is missing from `<a:xfrm>`

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFGroupShape.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFGroupShape.java
@@ -84,9 +84,15 @@ implements XSLFShapeContainer, GroupShape<XSLFShape,XSLFTextParagraph> {
     public Rectangle2D getAnchor(){
         CTGroupTransform2D xfrm = getXfrm();
         CTPoint2D off = xfrm.getOff();
+        if (off == null) {
+            return null;
+        }
         double x = Units.toPoints(POIXMLUnits.parseLength(off.xgetX()));
         double y = Units.toPoints(POIXMLUnits.parseLength(off.xgetY()));
         CTPositiveSize2D ext = xfrm.getExt();
+        if (ext == null) {
+            return null;
+        }
         double cx = Units.toPoints(ext.getCx());
         double cy = Units.toPoints(ext.getCy());
         return new Rectangle2D.Double(x,y,cx,cy);

--- a/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFSimpleShape.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFSimpleShape.java
@@ -128,9 +128,15 @@ public abstract class XSLFSimpleShape extends XSLFShape
         }
 
         CTPoint2D off = xfrm.getOff();
+        if (off == null) {
+            return null;
+        }
         double x = Units.toPoints(POIXMLUnits.parseLength(off.xgetX()));
         double y = Units.toPoints(POIXMLUnits.parseLength(off.xgetY()));
         CTPositiveSize2D ext = xfrm.getExt();
+        if (ext == null) {
+            return null;
+        }
         double cx = Units.toPoints(ext.getCx());
         double cy = Units.toPoints(ext.getCy());
         return new Rectangle2D.Double(x, y, cx, cy);


### PR DESCRIPTION
### Issue
When parsing PowerPoint files, some files may be missing the `<a:off>` tag from the `<a:xfrm>` section. While PowerPoint and other applications can open these files without issue, POI throws a `NullPointerException` when trying to retrieve the `anchor` of a shape that is missing this tag.

### Steps to reproduce:


1. Download [this file](https://github.com/higuaro/poi/files/10894211/poi-issue.zip) containing a Maven project, unzip the folder and `cd` into the `poi-issue` directory.
2. Run `maven install` and then `mvn exec:java`.
3. Observe the `NullPointerException` that is thrown:

```none
java.lang.NullPointerException: Cannot invoke "org.openxmlformats.schemas.drawingml.x2006.main.CTPoint2D.xgetX()" because "off" is null
    at org.apache.poi.xslf.usermodel.XSLFGroupShape.getAnchor (XSLFGroupShape.java:87)
    at com.example.Main.main (Main.java:17)
    at jdk.internal.reflect.DirectMethodHandleAccessor.invoke (DirectMethodHandleAccessor.java:104)
    at java.lang.reflect.Method.invoke (Method.java:578)
    at org.codehaus.mojo.exec.ExecJavaMojo$1.run (ExecJavaMojo.java:282)
    at java.lang.Thread.run (Thread.java:1589)
```

### Expected behavior
POI could gracefully handle missing `<a:off>` tags and not throw a `NullPointerException` when trying to retrieve the anchor of a shape that is missing this tag.

### Proposed solution
We are going to submit a pull request that makes the library return `null` in cases where the `<a:off>` tag is missing for both `XSLFGroupShape` and `XSLFSimpleShape`, instead of allowing the `NullPointerException` to occur.

Link to the original bug report: https://bz.apache.org/bugzilla/show_bug.cgi?id=66509